### PR TITLE
Minor updates for consistency in "Running Couchbase Server Under Joyent Triton"

### DIFF
--- a/blog/2015/05/05/running-couchbase-server-under-docker-on-joyent/index.html
+++ b/blog/2015/05/05/running-couchbase-server-under-docker-on-joyent/index.html
@@ -191,7 +191,7 @@
 </span><span class='line'>
 </span><span class='line'>    export DOCKER_CERT_PATH=/home/ubuntu/.sdc/docker/&lt;username&gt;
 </span><span class='line'>    export DOCKER_HOST=tcp://&lt;generated-ip&gt;:2376
-</span><span class='line'>    alias docker="docker --tls"
+</span><span class='line'>    export DOCKER_TLS_VERIFY=1
 </span><span class='line'>
 </span><span class='line'>Then you should be able to run 'docker info' and see your account
 </span><span class='line'>name 'SDCAccount: &lt;username&gt;' in the output.</span></code></pre></td></tr></table></div></figure>
@@ -206,7 +206,7 @@
 <span class='line-number'>3</span>
 </pre></td><td class='code'><pre><code class=''><span class='line'>$ export DOCKER_CERT_PATH=/home/ubuntu/.sdc/docker/&lt;username&gt;
 </span><span class='line'>$ export DOCKER_HOST=tcp://&lt;generated-ip&gt;:2376
-</span><span class='line'>$ alias docker="docker --tls"</span></code></pre></td></tr></table></div></figure>
+</span><span class='line'>$ export DOCKER_TLS_VERIFY=1</span></code></pre></td></tr></table></div></figure>
 
 
 <h2>Docker Hello World</h2>
@@ -300,9 +300,9 @@
 <figure class='code'><div class="highlight"><table><tr><td class="gutter"><pre class="line-numbers"><span class='line-number'>1</span>
 <span class='line-number'>2</span>
 <span class='line-number'>3</span>
-</pre></td><td class='code'><pre><code class=''><span class='line'>$ container_1_ip=`docker inspect $container_1 | grep -i IPAddress | awk -F: '{print $2}' |  grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b"`
-</span><span class='line'>$ container_2_ip=`docker inspect $container_2 | grep -i IPAddress | awk -F: '{print $2}' |  grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b"`
-</span><span class='line'>$ container_3_ip=`docker inspect $container_3 | grep -i IPAddress | awk -F: '{print $2}' |  grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b"`
+</pre></td><td class='code'><pre><code class=''><span class='line'>$ container_1_ip=`docker inspect -f '{{.NetworkSettings.IPAddress}}' $container_1`
+</span><span class='line'>$ container_2_ip=`docker inspect -f '{{.NetworkSettings.IPAddress}}' $container_2`
+</span><span class='line'>$ container_3_ip=`docker inspect -f '{{.NetworkSettings.IPAddress}}' $container_3`
 </span></code></pre></td></tr></table></div></figure>
 
 
@@ -346,8 +346,8 @@
 <span class='line-number'>4</span>
 <span class='line-number'>5</span>
 <span class='line-number'>6</span>
-</pre></td><td class='code'><pre><code class=''><span class='line'>$ docker run --rm --entrypoint=/opt/couchbase/bin/couchbase-cli couchbase/server \
-</span><span class='line'>cluster-init -c $container_1_ip \
+</pre></td><td class='code'><pre><code class=''><span class='line'>$ docker run --rm couchbase/server \
+</span><span class='line'>couchbase-cli cluster-init -c $container_1_ip \
 </span><span class='line'>--cluster-init-username=Administrator \
 </span><span class='line'>--cluster-init-password=password \
 </span><span class='line'>--cluster-init-ramsize=600 \
@@ -372,14 +372,14 @@
 <span class='line-number'>6</span>
 <span class='line-number'>7</span>
 <span class='line-number'>8</span>
-</pre></td><td class='code'><pre><code class=''><span class='line'>$ docker run --rm --entrypoint=/opt/couchbase/bin/couchbase-cli couchbase/server \
-</span><span class='line'>bucket-create -c $container_1_ip:8091 \
+</pre></td><td class='code'><pre><code class=''><span class='line'>$ docker run --rm couchbase/server \
+</span><span class='line'>couchbase-cli bucket-create -c $container_1_ip \
+</span><span class='line'>-u Administrator -p password \
 </span><span class='line'>--bucket=default \
 </span><span class='line'>--bucket-type=couchbase \
 </span><span class='line'>--bucket-port=11211 \
 </span><span class='line'>--bucket-ramsize=600 \
-</span><span class='line'>--bucket-replica=1 \
-</span><span class='line'>-u Administrator -p password</span></code></pre></td></tr></table></div></figure>
+</span><span class='line'>--bucket-replica=1</span></code></pre></td></tr></table></div></figure>
 
 
 <p>You should see:</p>
@@ -398,8 +398,8 @@
 <span class='line-number'>4</span>
 <span class='line-number'>5</span>
 <span class='line-number'>6</span>
-</pre></td><td class='code'><pre><code class=''><span class='line'>$ docker run --rm --entrypoint=/opt/couchbase/bin/couchbase-cli couchbase/server \
-</span><span class='line'>server-add -c $container_1_ip \
+</pre></td><td class='code'><pre><code class=''><span class='line'>$ docker run --rm couchbase/server \
+</span><span class='line'>couchbase-cli server-add -c $container_1_ip \
 </span><span class='line'>-u Administrator -p password \
 </span><span class='line'>--server-add $container_2_ip \
 </span><span class='line'>--server-add-username Administrator \
@@ -417,8 +417,8 @@
 <figure class='code'><div class="highlight"><table><tr><td class="gutter"><pre class="line-numbers"><span class='line-number'>1</span>
 <span class='line-number'>2</span>
 <span class='line-number'>3</span>
-</pre></td><td class='code'><pre><code class=''><span class='line'>$ docker run --rm --entrypoint=/opt/couchbase/bin/couchbase-cli couchbase/server \
-</span><span class='line'>server-list -c $container_1_ip \
+</pre></td><td class='code'><pre><code class=''><span class='line'>$ docker run --rm couchbase/server \
+</span><span class='line'>couchbase-cli server-list -c $container_1_ip \
 </span><span class='line'>-u Administrator -p password</span></code></pre></td></tr></table></div></figure>
 
 
@@ -446,8 +446,8 @@
 <span class='line-number'>4</span>
 <span class='line-number'>5</span>
 <span class='line-number'>6</span>
-</pre></td><td class='code'><pre><code class=''><span class='line'>$ docker run --rm --entrypoint=/opt/couchbase/bin/couchbase-cli couchbase/server \
-</span><span class='line'>rebalance -c $container_1_ip \
+</pre></td><td class='code'><pre><code class=''><span class='line'>$ docker run --rm couchbase/server \
+</span><span class='line'>couchbase-cli rebalance -c $container_1_ip \
 </span><span class='line'>-u Administrator -p password \
 </span><span class='line'>--server-add $container_3_ip \
 </span><span class='line'>--server-add-username Administrator \


### PR DESCRIPTION
This includes a fix to the output of `./tools/sdc-docker-setup.sh` (using `DOCKER_TLS_VERIFY` instead of `alias docker='docker --tls'`). :+1:

This also takes advantage of https://github.com/couchbase/docker/pull/2 to make the `couchbase-cli` usage easier to read (removing `--entrypoint` now that the built-in entrypoint script can handle this without override).  I took the liberty of also moving the `-u Administrator -p password` parts to come first in all the examples for consistency. :innocent:
